### PR TITLE
new: trailer headers support

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -190,6 +190,11 @@ func (r *Runner) executeTest(v models.TestInterface) (*models.Result, error) {
 		Test:                v,
 	}
 
+	// support for Trailer headers: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Trailer
+	for name, value := range resp.Trailer {
+		result.ResponseHeaders[name] = value
+	}
+
 	// launch script in cmd interface
 	if v.AfterRequestScriptPath() != "" {
 		if err := cmd_runner.CmdRun(v.AfterRequestScriptPath(), v.AfterRequestScriptTimeout()); err != nil {


### PR DESCRIPTION
Support for Trailer headers:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Trailer
https://pkg.go.dev/net/http#Response