### PR TITLE
new: pass address of test server (not full server object)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,7 @@ func TestFuncCases(t *testing.T) {
 	defer srv.Close()
 
 	// run test cases from current folder
-	runner.RunWithTesting(t, &runner.RunWithTestingParams{
-		Server:      srv,
+	runner.RunWithTesting(t, srv.URL, &runner.RunWithTestingParams{
 		TestsDir:    "cases",      // test case folder
 		FixturesDir: "fixtures",   // fixtures folder
 		Mocks:       m,
@@ -627,8 +626,7 @@ defer srv.Close()
 As soon as you spinned up your mocks and configured your service, you can run the tests.
 
 ```go
-runner.RunWithTesting(t, &runner.RunWithTestingParams{
-	Server:   srv,
+runner.RunWithTesting(t, srv.URL, &runner.RunWithTestingParams{
 	TestsDir: "tests/cases",
 	Mocks:    m, // pass the mocks to the test runner
 })

--- a/examples/mock-based-on-request/func_test.go
+++ b/examples/mock-based-on-request/func_test.go
@@ -20,7 +20,7 @@ func TestProxy(t *testing.T) {
 	initServer()
 	srv := httptest.NewServer(nil)
 
-	runner.RunWithTesting(t, srv, &runner.RunWithTestingOpts{
+	runner.RunWithTesting(t, srv.URL, &runner.RunWithTestingOpts{
 		TestsDir: "cases",
 		Mocks:    m,
 	})

--- a/examples/mock-body-matching/func_test.go
+++ b/examples/mock-body-matching/func_test.go
@@ -20,7 +20,7 @@ func TestProxy(t *testing.T) {
 	initServer()
 	srv := httptest.NewServer(nil)
 
-	runner.RunWithTesting(t, srv, &runner.RunWithTestingOpts{
+	runner.RunWithTesting(t, srv.URL, &runner.RunWithTestingOpts{
 		TestsDir: "cases",
 		Mocks:    m,
 	})

--- a/examples/mock-field-json-str/func_test.go
+++ b/examples/mock-field-json-str/func_test.go
@@ -20,7 +20,7 @@ func TestProxy(t *testing.T) {
 	initServer()
 	srv := httptest.NewServer(nil)
 
-	runner.RunWithTesting(t, srv, &runner.RunWithTestingOpts{
+	runner.RunWithTesting(t, srv.URL, &runner.RunWithTestingOpts{
 		TestsDir: "cases",
 		Mocks:    m,
 	})

--- a/examples/mock-xml-matching/func_test.go
+++ b/examples/mock-xml-matching/func_test.go
@@ -20,7 +20,7 @@ func TestProxy(t *testing.T) {
 	initServer()
 	srv := httptest.NewServer(nil)
 
-	runner.RunWithTesting(t, srv, &runner.RunWithTestingOpts{
+	runner.RunWithTesting(t, srv.URL, &runner.RunWithTestingOpts{
 		TestsDir: "cases",
 		Mocks:    m,
 	})

--- a/examples/traffic-lights-demo/func_test.go
+++ b/examples/traffic-lights-demo/func_test.go
@@ -12,7 +12,7 @@ func Test_API(t *testing.T) {
 
 	srv := httptest.NewServer(nil)
 
-	runner.RunWithTesting(t, srv, &runner.RunWithTestingOpts{
+	runner.RunWithTesting(t, srv.URL, &runner.RunWithTestingOpts{
 		TestsDir: "tests/cases",
 	})
 }

--- a/examples/with-cases-example/func_test.go
+++ b/examples/with-cases-example/func_test.go
@@ -20,7 +20,7 @@ func TestProxy(t *testing.T) {
 	initServer()
 	srv := httptest.NewServer(nil)
 
-	runner.RunWithTesting(t, srv, &runner.RunWithTestingOpts{
+	runner.RunWithTesting(t, srv.URL, &runner.RunWithTestingOpts{
 		TestsDir: "cases",
 		Mocks:    m,
 	})

--- a/examples/xml-body-matching/func_test.go
+++ b/examples/xml-body-matching/func_test.go
@@ -11,7 +11,7 @@ func TestProxy(t *testing.T) {
 	initServer()
 	srv := httptest.NewServer(nil)
 
-	runner.RunWithTesting(t, srv, &runner.RunWithTestingOpts{
+	runner.RunWithTesting(t, srv.URL, &runner.RunWithTestingOpts{
 		TestsDir: "cases",
 	})
 }

--- a/runner/previous_result_test.go
+++ b/runner/previous_result_test.go
@@ -16,7 +16,7 @@ func Test_PreviousResult(t *testing.T) {
 	srv := testServer()
 	defer srv.Close()
 
-	RunWithTesting(t, srv, &RunWithTestingOpts{
+	RunWithTesting(t, srv.URL, &RunWithTestingOpts{
 		TestsDir: filepath.Join("testdata", "previous-result"),
 	})
 }

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -11,7 +11,7 @@ func TestDontFollowRedirects(t *testing.T) {
 	srv := testServerRedirect()
 	defer srv.Close()
 
-	RunWithTesting(t, srv, &RunWithTestingOpts{
+	RunWithTesting(t, srv.URL, &RunWithTestingOpts{
 		TestsDir: filepath.Join("testdata", "dont-follow-redirects"),
 	})
 }

--- a/runner/runner_testing.go
+++ b/runner/runner_testing.go
@@ -3,7 +3,6 @@ package runner
 import (
 	"errors"
 	"fmt"
-	"net/http/httptest"
 	"net/url"
 	"os"
 	"strings"
@@ -51,7 +50,7 @@ func registerMocksEnvironment(m *mocks.Mocks) {
 
 // RunWithTesting is a helper function the wraps the common Run and provides simple way
 // to configure Gonkex by filling the params structure.
-func RunWithTesting(t *testing.T, server *httptest.Server, opts *RunWithTestingOpts) {
+func RunWithTesting(t *testing.T, serverURL string, opts *RunWithTestingOpts) {
 	if opts.Mocks != nil {
 		registerMocksEnvironment(opts.Mocks)
 	}
@@ -77,7 +76,7 @@ func RunWithTesting(t *testing.T, server *httptest.Server, opts *RunWithTestingO
 	handler := testingHandler{t}
 	runner := New(
 		&Config{
-			Host:         server.URL,
+			Host:         serverURL,
 			Mocks:        opts.Mocks,
 			FixturesDir:  opts.FixturesDir,
 			DB:           opts.DB,

--- a/runner/runner_upload_file_test.go
+++ b/runner/runner_upload_file_test.go
@@ -16,7 +16,7 @@ func TestUploadFiles(t *testing.T) {
 	defer srv.Close()
 
 	// TODO: refactor RunWithTesting() for testing negative scenario (when tests has expected errors)
-	RunWithTesting(t, srv, &RunWithTestingOpts{
+	RunWithTesting(t, srv.URL, &RunWithTestingOpts{
 		TestsDir: filepath.Join("testdata", "upload-files"),
 	})
 }


### PR DESCRIPTION
awe don't use `httptest.Server` object, but pass it to `RunWithTesting`.  So now I pass address of this service and we can pass address of any server to this function now.