### PR TITLE
new: allows to get variables value from headers and cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,8 @@ Example:
 - name: "get_last_post_id"
   ...
   variables_to_set:
-    200: "id"
+    200:
+      id: ""                      # store whole text body to variable
 
 # if the response is JSON
 - name: "get_last_post_info"
@@ -374,15 +375,24 @@ Example:
     200:
       id: "id"
       title: "title"
-      authorId: "author_info.id"
+      authorId: "author_info.id"  # get nested json fields here (any nesting levels are supported)
+      wholeBody: ""               # store whole text body to variable
 ```
 
-You can access nested json fields like this:
-> "author_info.id"
+It is also possible to retrieve values from the headers and cookies of a query. To do this, specify the prefix "header:" or "cookie:" in the path, respectively. For example,
 
-Any nesting levels are supported.
+```yaml
+- name: "get_last_post_id"
+  ...
+  variables_to_set:
+    302:
+      newLocation: "header:Location"    # get value from "Location" header
+      sessionId: "cookie:session_id"    # get value from "session_id" cookie
+      authorId: "body:author_info.id"   # optional "body:" prefix allows to get value from body
+```
 
-#### From the response of currently running test
+
+#### From the response body of currently running test
 
 Example:
 

--- a/runner/variables_to_set_test.go
+++ b/runner/variables_to_set_test.go
@@ -3,29 +3,30 @@ package runner
 import (
 	"testing"
 
+	"github.com/lansfy/gonkex/models"
+
 	"github.com/stretchr/testify/require"
 )
 
-func TestFromResponse(t *testing.T) {
+func Test_extractVariablesFromJSONResponse(t *testing.T) {
+	body := `{"key1": "value1", "key2": "value2"}`
 	tests := []struct {
 		description string
 		varsToSet   map[string]string
-		body        string
-		isJSON      bool
 		want        map[string]string
 		wantErr     string
 	}{
 		{
 			description: "json body with valid paths",
 			varsToSet: map[string]string{
-				"var1": "key1",
-				"var2": "key2",
+				"var1":         "key1",
+				"var2":         "key2",
+				"wholeBodyVar": "",
 			},
-			body:   `{"key1": "value1", "key2": "value2"}`,
-			isJSON: true,
 			want: map[string]string{
-				"var1": "value1",
-				"var2": "value2",
+				"var1":         "value1",
+				"var2":         "value2",
+				"wholeBodyVar": body,
 			},
 		},
 		{
@@ -34,36 +35,189 @@ func TestFromResponse(t *testing.T) {
 				"var1": "key1",
 				"var2": "missingKey",
 			},
-			body:    `{"key1": "value1"}`,
-			isJSON:  true,
 			wantErr: "variable 'var2': path missingKey does not exist in service response",
 		},
 		{
-			description: "plain text body with valid variable",
+			description: "json body with valid paths and optional prefix",
 			varsToSet: map[string]string{
-				"var1": "unusedPath",
+				"var1":         "body:key1",
+				"var2":         "body: key2 ",
+				"wholeBodyVar": "body:",
 			},
-			body:   "plain text value",
-			isJSON: false,
 			want: map[string]string{
-				"var1": "plain text value",
+				"var1":         "value1",
+				"var2":         "value2",
+				"wholeBodyVar": body,
 			},
-		},
-		{
-			description: "plain text body with multiple variables",
-			varsToSet: map[string]string{
-				"var1": "unusedPath",
-				"var2": "unusedPath2",
-			},
-			body:    "plain text value",
-			isJSON:  false,
-			wantErr: "count of variables for plain-text response should be 1, 2 given",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			got, err := extractVariablesFromResponse(tt.varsToSet, tt.body, tt.isJSON)
+			result := &models.Result{
+				ResponseBody:        body,
+				ResponseContentType: "json",
+			}
+			got, err := extractVariablesFromResponse(tt.varsToSet, result)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.EqualError(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func Test_extractVariablesFromPlainResponse(t *testing.T) {
+	body := "plain text value"
+	tests := []struct {
+		description string
+		varsToSet   map[string]string
+		want        map[string]string
+		wantErr     string
+	}{
+		{
+			description: "plain text body with valid variable",
+			varsToSet: map[string]string{
+				"var1": "",
+			},
+			want: map[string]string{
+				"var1": body,
+			},
+		},
+		{
+			description: "plain text body with non-empty path",
+			varsToSet: map[string]string{
+				"var1": "some.path",
+			},
+			wantErr: "variable 'var1': paths not supported for plain text body",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			result := &models.Result{
+				ResponseBody:        body,
+				ResponseContentType: "text",
+			}
+
+			got, err := extractVariablesFromResponse(tt.varsToSet, result)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.EqualError(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func Test_extractVariablesFromHeaders(t *testing.T) {
+	headers := map[string][]string{
+		"Test-Header-1": {"aaa", "bbb"},
+		"Test-Header-2": {"ccc"},
+	}
+
+	tests := []struct {
+		description string
+		varsToSet   map[string]string
+		want        map[string]string
+		wantErr     string
+	}{
+		{
+			description: "variables with valid header name",
+			varsToSet: map[string]string{
+				"var1": "header:Test-Header-1",
+				"var2": "header: Test-Header-2 ",
+			},
+			want: map[string]string{
+				"var1": "aaa",
+				"var2": "ccc",
+			},
+		},
+		{
+			description: "variables with unknown header",
+			varsToSet: map[string]string{
+				"var1": "header:Test-Header-1",
+				"var3": "header:Wrong-Header",
+			},
+			wantErr: "variable 'var3': response does not include expected header 'Wrong-Header'",
+		},
+		{
+			description: "variables with unknown prefix",
+			varsToSet: map[string]string{
+				"var1": "header:Test-Header-1",
+				"var3": "wrong-prefix:Test-Header-1",
+			},
+			wantErr: "variable 'var3': unexpected path prefix 'wrong-prefix' (allowed only [body header cookie])",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			result := &models.Result{
+				ResponseHeaders: headers,
+			}
+			got, err := extractVariablesFromResponse(tt.varsToSet, result)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.EqualError(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func Test_extractVariablesFromCookie(t *testing.T) {
+	headers := map[string][]string{
+		"Set-Cookie": {
+			"session_id=abc123; Path=/; HttpOnly",
+			"user", // ignored, because has wrong format
+			"user=JohnDoe; Path=/; Secure",
+		},
+	}
+
+	tests := []struct {
+		description string
+		varsToSet   map[string]string
+		want        map[string]string
+		wantErr     string
+	}{
+		{
+			description: "variables with valid cookie name",
+			varsToSet: map[string]string{
+				"var1": "cookie:session_id",
+				"var2": "cookie: user ",
+			},
+			want: map[string]string{
+				"var1": "abc123",
+				"var2": "JohnDoe",
+			},
+		},
+		{
+			description: "variables with unknown cookie",
+			varsToSet: map[string]string{
+				"var1": "cookie:session_id",
+				"var2": "cookie:wrong_name",
+			},
+			wantErr: "variable 'var2': Set-Cookie header does not include expected cookie 'wrong_name'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			result := &models.Result{
+				ResponseHeaders: headers,
+			}
+			got, err := extractVariablesFromResponse(tt.varsToSet, result)
 
 			if tt.wantErr != "" {
 				require.Error(t, err)


### PR DESCRIPTION
#### From the response of the previous test

Example:

```yaml
# if the response is plain text
- name: "get_last_post_id"
  ...
  variables_to_set:
    200:
      id: ""                      # store whole text body to variable

# if the response is JSON
- name: "get_last_post_info"
  ...
  variables_to_set:
    200:
      id: "id"
      title: "title"
      authorId: "author_info.id"  # get nested json fields here (any nesting levels are supported)
      wholeBody: ""               # store whole text body to variable
```

It is also possible to retrieve values from the headers and cookies of a query. To do this, specify the prefix "header:" or "cookie:" in the path, respectively. For example,

```yaml
- name: "get_last_post_id"
  ...
  variables_to_set:
    302:
      newLocation: "header:Location"    # get value from "Location" header
      sessionId: "cookie:session_id"    # get value from "session_id" cookie
      authorId: "body:author_info.id"   # optional "body:" prefix allows to get value from body
```
