### PR TITLE
new: implement $matchArray with subset value

### DIFF
--- a/compare/compare_test.go
+++ b/compare/compare_test.go
@@ -146,7 +146,7 @@ var complexJson1 string
 //go:embed testdata/complex_data_2.json
 var complexJson2 string
 
-func TestCompareJson(t *testing.T) {
+func Test_compareJson(t *testing.T) {
 	tests := []struct {
 		name     string
 		expected string
@@ -210,23 +210,6 @@ func TestCompareJson(t *testing.T) {
 			expected: `["2", "$matchRegexp(x.+z)"]`,
 			actual:   `["2", "ayyyb"]`,
 			wantErr:  makeErrorString("$[1]", "value does not match regexp", "$matchRegexp(x.+z)", "ayyyb"),
-		},
-		{
-			name:     "WHEN first element in array is $matchArray(pattern) next element MUST treat as template for all elements in this array",
-			expected: `["$matchArray(pattern)", ["$matchRegexp(^[0-4]+$)", "a"]]`,
-			actual:   `[["12", "a"], ["34", "a"], ["03", "a"]]`,
-		},
-		{
-			name:     "WHEN use $matchArray(pattern) and one element of array does not match the pattern, the check MUST fail",
-			expected: `["$matchArray(pattern)", ["$matchRegexp(^[0-4]+$)", "a"]]`,
-			actual:   `[["12", "a"], ["34", "a"], ["45", "a"]]`,
-			wantErr:  makeErrorString("$[2][0]", "value does not match regexp", "$matchRegexp(^[0-4]+$)", "45"),
-		},
-		{
-			name:     "WHEN use $matchArray(pattern) and didn't provide pattern, the check MUST fail",
-			expected: `["$matchArray(pattern)"]`,
-			actual:   `[["12", "a"], ["34", "a"]]`,
-			wantErr:  makeErrorString("$", "$matchArray(pattern) require only one additional element in array", 1, 0),
 		},
 		{
 			name:     "equal maps MUST be equal",
@@ -327,6 +310,124 @@ func TestCompareJson(t *testing.T) {
 				"#/parameters/profile_id",
 				"#/parameters/profile_id2",
 			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var json1, json2 interface{}
+			err := json.Unmarshal([]byte(tt.expected), &json1)
+			require.NoError(t, err)
+			err = json.Unmarshal([]byte(tt.actual), &json2)
+			require.NoError(t, err)
+
+			errors := Compare(json1, json2, tt.params)
+			if tt.wantErr == "" {
+				require.Empty(t, errors)
+			} else {
+				require.Len(t, errors, 1)
+				require.Equal(t, tt.wantErr, errors[0].Error())
+			}
+		})
+	}
+}
+
+func Test_matchArray(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+		actual   string
+		params   Params
+		wantErr  string
+	}{
+		{
+			name:     "$matchArray(pattern) works",
+			expected: `["$matchArray(pattern)", "$matchRegexp(^[0-9]+$)"]`,
+			actual:   `["123", "456", "7", "8", "9"]`,
+		},
+		{
+			name:     "$matchArray(pattern) works on empty array",
+			expected: `["$matchArray(pattern)", "$matchRegexp(^[0-9]+$)"]`,
+			actual:   `[]`,
+		},
+		{
+			name:     "$matchArray(subset+pattern) works",
+			expected: `["$matchArray(subset+pattern)", "a", "b", "c", "$matchRegexp(^[0-9]+$)"]`,
+			actual:   `["a", "b", "c", "5", "6"]`,
+		},
+		{
+			name:     "$matchArray(subset+pattern) works WHEN no extra elements",
+			expected: `["$matchArray(subset+pattern)", "a", "b", "c", "$matchRegexp(^[0-9]+$)"]`,
+			actual:   `["a", "b", "c"]`,
+		},
+		{
+			name:     "$matchArray(pattern+subset) works",
+			expected: `["$matchArray(pattern+subset)", "$matchRegexp(^[0-9]+$)", "a", "b", "c"]`,
+			actual:   `["5", "6", "a", "b", "c"]`,
+		},
+		{
+			name:     "$matchArray(pattern+subset) works WHEN no extra elements",
+			expected: `["$matchArray(pattern+subset)", "$matchRegexp(^[0-9]+$)", "a", "b", "c"]`,
+			actual:   `["a", "b", "c"]`,
+		},
+		{
+			name:     "WHEN $matchArray has unknown mode MUST fail with error",
+			expected: `["$matchArray(errorhere)", ["$matchRegexp(^[0-4]+$)", "a"]]`,
+			actual:   `[]`,
+			wantErr:  makeErrorString("$", "unknown $matchArray mode", "pattern / pattern+subset / subset+pattern", "errorhere"),
+		},
+		{
+			name:     "WHEN first element in array is $matchArray(pattern) next element MUST treat as template for all elements in this array",
+			expected: `["$matchArray(pattern)", ["$matchRegexp(^[0-4]+$)", "a"]]`,
+			actual:   `[["12", "a"], ["34", "a"], ["03", "a"]]`,
+		},
+		{
+			name:     "WHEN use $matchArray(pattern) and one element of array does not match the pattern, the check MUST fail",
+			expected: `["$matchArray(pattern)", ["$matchRegexp(^[0-4]+$)", "a"]]`,
+			actual:   `[["12", "a"], ["34", "a"], ["45", "a"]]`,
+			wantErr:  makeErrorString("$[2][0]", "value does not match regexp", "$matchRegexp(^[0-4]+$)", "45"),
+		},
+		{
+			name:     "WHEN use $matchArray(subset+pattern) and one element of array does not match the pattern, the check MUST fail",
+			expected: `["$matchArray(subset+pattern)", "a", "b", "c", "$matchRegexp(^[0-9]+$)"]`,
+			actual:   `["a", "b", "c", "d", "5"]`,
+			wantErr:  makeErrorString("$[3]", "value does not match regexp", "$matchRegexp(^[0-9]+$)", "d"),
+		},
+		{
+			name:     "WHEN use $matchArray(subset+pattern) and header of array does not match the subset, the check MUST fail",
+			expected: `["$matchArray(subset+pattern)", "a", "b", "b", "$matchRegexp(^[0-9]+$)"]`,
+			actual:   `["a", "b", "c", "5", "6"]`,
+			wantErr:  makeErrorString("$[2]", "values do not match", "b", "c"),
+		},
+		{
+			name:     "WHEN use $matchArray(pattern+subset) and one element of array does not match the pattern, the check MUST fail",
+			expected: `["$matchArray(pattern+subset)", "$matchRegexp(^[0-9]+$)", "a", "b", "c"]`,
+			actual:   `["d", "5", "a", "b", "c"]`,
+			wantErr:  makeErrorString("$[0]", "value does not match regexp", "$matchRegexp(^[0-9]+$)", "d"),
+		},
+		{
+			name:     "WHEN use $matchArray(pattern+subset) and footer of array does not match the subset, the check MUST fail",
+			expected: `["$matchArray(pattern+subset)", "$matchRegexp(^[0-9]+$)", "b", "b", "c"]`,
+			actual:   `["5", "6", "a", "b", "c"]`,
+			wantErr:  makeErrorString("$[2]", "values do not match", "b", "a"),
+		},
+		{
+			name:     "WHEN use $matchArray(pattern) and didn't provide pattern, the check MUST fail",
+			expected: `["$matchArray(pattern)"]`,
+			actual:   `[["12", "a"], ["34", "a"]]`,
+			wantErr:  "path '$': array with $matchArray(pattern) must pattern element",
+		},
+		{
+			name:     "WHEN use $matchArray(pattern+subset) and didn't provide pattern or subset, the check MUST fail",
+			expected: `["$matchArray(pattern+subset)", "aaaa"]`,
+			actual:   `[]`,
+			wantErr:  "path '$': array with $matchArray(pattern+subset) must have pattern and additional elements",
+		},
+		{
+			name:     "WHEN use $matchArray(subset+pattern) and didn't provide pattern or subset, the check MUST fail",
+			expected: `["$matchArray(subset+pattern)", "aaaa"]`,
+			actual:   `[]`,
+			wantErr:  "path '$': array with $matchArray(subset+pattern) must have pattern and additional elements",
 		},
 	}
 


### PR DESCRIPTION
### $matchArray

The `$matchArray` feature allows you to validate that all elements in an array match a specific pattern. This is especially useful when:

- you don't know exactly how many elements will be in the array;
- all elements in the array should follow the same pattern or structure;
- you want to avoid repetitive pattern definitions for large arrays.

#### $matchArray(pattern)

To use `$matchArray`, you need to define an array with exactly two elements:

- the literal string `$matchArray(pattern)`;
- a pattern object that defines what each array element should match.

Example:

```yaml
- name: WHEN orders information is requested, service MUST return valid orders data
  method: GET
  path: /api/orders

  response:
    200: >
      {
        "user": "testuser",
        "orders": [
          "$matchArray(pattern)",
          {
            "order_id": "$matchRegexp(^ORDER[0-9]{4}$)",
            "amount": "$matchRegexp(^[0-9]+\\.?[0-9]*$)",
            "status": "$matchRegexp(pending|processing|completed)"
          }
        ]
      }
```

This pattern will match arrays of any length, as long as all elements follow the specified structure.

#### $matchArray(subset+pattern)

In this mode:

- the first element in your test array must be the literal string `$matchArray(subset+pattern)`;
- the last element defines the pattern that any additional elements in the response array must match;
- all elements between these two (the subset) are treated as required initial elements that must appear at the beginning of the response array in the exact order specified;
- after matching these initial elements, any remaining elements in the response array must match the pattern defined in the last element.

*NOTE*: you still can use the `ignoreArraysOrdering` parameter with `$matchArray(subset+pattern)`.
When set to `true`, this parameter allows the subset elements to appear anywhere in the array, not just at the beginning, while still maintaining the pattern matching for additional elements.

#### $matchArray(pattern+subset)

In this mode:

- the first element in your test array must be the literal string `$matchArray(pattern+subset)`;
- the second element defines the pattern that any leading elements in the response array must match;
- all elements after these two (the subset) are treated as required final elements that must appear at the end of the response array in the exact order specified;
- the beginning of the response array must contain zero or more elements that match the pattern defined in the second element.

```yaml
- name: WHEN products are requested, service MUST return regular products followed by featured products
  method: GET
  path: /api/products
  response:
    200: >
      {
        "products": [
          "$matchArray(pattern+subset)",
          {
            "product_id": "$matchRegexp(^PROD-[A-Z0-9]{6}$)",
            "price": "$matchRegexp(^\\d+\\.\\d{2}$)",
            "featured": false
          },
          {
            "product_id": "FEATURED-001",
            "price": "29.99",
            "featured": true
          },
          {
            "product_id": "FEATURED-002",
            "price": "49.99",
            "featured": true
          }
        ]
      }
```

*NOTE*: you still can use the `ignoreArraysOrdering` parameter with `$matchArray(pattern+subset)`.
When set to `true`, this parameter allows the subset elements to appear anywhere in the array, not just at the end, while still maintaining the pattern matching for additional elements.
