### PR TITLE
new: improve matchTime functionality

### DIFF
--- a/compare/matcher_args.go
+++ b/compare/matcher_args.go
@@ -1,0 +1,49 @@
+package compare
+
+import (
+	"fmt"
+	"strings"
+)
+
+func extractArgs(input string, defaultParams map[string]string) (string, map[string]string, error) {
+	parts := strings.Split(input, ",")
+	baseValue := ""
+	if len(parts) != 0 {
+		baseValue = parts[0]
+	}
+
+	params := map[string]string{}
+	for i := 1; i < len(parts); i++ {
+		keyValue := strings.SplitN(parts[i], "=", 2)
+		if len(keyValue) != 2 {
+			return "", nil, makeParamError(parts[i], "invalid parameter format")
+		}
+
+		key := strings.TrimSpace(keyValue[0])
+		if key == "" {
+			return "", nil, makeParamError(parts[i], "empty parameter name")
+		}
+
+		if _, ok := defaultParams[key]; !ok {
+			return "", nil, makeParamError(parts[i], "unknown parameter name")
+		}
+
+		if _, ok := params[key]; ok {
+			return "", nil, makeParamError(parts[i], "duplicate parameter name")
+		}
+
+		params[key] = keyValue[1]
+	}
+
+	for key, value := range defaultParams {
+		if _, ok := params[key]; !ok {
+			params[key] = value
+		}
+	}
+
+	return baseValue, params, nil
+}
+
+func makeParamError(part, message string) error {
+	return fmt.Errorf("parameter '%s': %s", part, message)
+}

--- a/compare/matcher_args_test.go
+++ b/compare/matcher_args_test.go
@@ -1,0 +1,86 @@
+package compare
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_extractArgs(t *testing.T) {
+	defaultParams := map[string]string{
+		"param1": "default1",
+		"param2": "default2",
+	}
+	tests := []struct {
+		description string
+		input       string
+		wantParams  map[string]string
+		wantErr     string
+	}{
+		{
+			description: "only value, no additional params",
+			input:       "somevalue",
+			wantParams:  defaultParams,
+		},
+		{
+			description: "value with one additional param",
+			input:       "somevalue,param1=aaa",
+			wantParams: map[string]string{
+				"param1": "aaa",
+				"param2": "default2",
+			},
+		},
+		{
+			description: "value with two additional params",
+			input:       "somevalue,param2=bbb,param1=aaa",
+			wantParams: map[string]string{
+				"param1": "aaa",
+				"param2": "bbb",
+			},
+		},
+		{
+			description: "value with two additional params (and spaces in name)",
+			input:       "somevalue, param2 =bbb, param1=aaa",
+			wantParams: map[string]string{
+				"param1": "aaa",
+				"param2": "bbb",
+			},
+		},
+		{
+			description: "invalid parameter format (no '=') not allowed",
+			input:       "somevalue,bar",
+			wantErr:     "parameter 'bar': invalid parameter format",
+		},
+		{
+			description: "empty parameter name not allowed",
+			input:       "somevalue,=value",
+			wantErr:     "parameter '=value': empty parameter name",
+		},
+		{
+			description: "unknown name in parameters",
+			input:       "somevalue,baz=value",
+			wantErr:     "parameter 'baz=value': unknown parameter name",
+		},
+		{
+			description: "duplicate key in param",
+			input:       "somevalue,param1=value1,param1=value2",
+			wantErr:     "parameter 'param1=value2': duplicate parameter name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			gotBase, gotParams, err := extractArgs(tt.input, defaultParams)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.EqualError(t, err, tt.wantErr)
+				require.Equal(t, "", gotBase)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, "somevalue", gotBase)
+				require.Equal(t, tt.wantParams, gotParams)
+			}
+		})
+	}
+}

--- a/compare/matcher_time_test.go
+++ b/compare/matcher_time_test.go
@@ -1,12 +1,116 @@
 package compare
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
 func Test_TimeMatcher_MatchValues(t *testing.T) {
+	oldNowTimeFunc := nowTimeFunc
+	nowTimeFunc = func() time.Time {
+		return time.Date(2023, 12, 25, 10, 20, 30, 0, time.Local)
+	}
+	defer func() {
+		nowTimeFunc = oldNowTimeFunc
+	}()
+
+	tests := []struct {
+		description string
+		matcher     *timeMatcher
+		actual      interface{}
+	}{
+		{
+			description: "matchTime MUST support strftime pattern",
+			matcher:     &timeMatcher{data: "%Y-%m-%d %H:%M:%S"},
+			actual:      "2023-12-25 10:20:30",
+		},
+		{
+			description: "matchTime MUST support golang pattern",
+			matcher:     &timeMatcher{data: "2006-01-02 15:04:05"},
+			actual:      "2023-12-25 10:20:30",
+		},
+		{
+			description: "matchTime MUST support 'now' function",
+			matcher:     &timeMatcher{data: "%d-%m-%Y %H:%M:%S, value=now"},
+			actual:      "25-12-2023 10:20:30",
+		},
+		{
+			description: "matchTime MUST support 'now()' function",
+			matcher:     &timeMatcher{data: "%d-%m-%Y %H:%M:%S, value=now()"},
+			actual:      "25-12-2023 10:20:30",
+		},
+		{
+			description: "time MUST check with accuracy precision (up to 5m after)",
+			matcher:     &timeMatcher{data: "%d-%m-%Y %H:%M:%S, value=now"},
+			actual:      "25-12-2023 10:25:30",
+		},
+		{
+			description: "time MUST check with accuracy precision (up to 5m before)",
+			matcher:     &timeMatcher{data: "%d-%m-%Y %H:%M:%S, value=now"},
+			actual:      "25-12-2023 10:15:30",
+		},
+		{
+			description: "expected time MUST support negative offset",
+			matcher:     &timeMatcher{data: "%d-%m-%Y %H:%M:%S, value=now-1h"},
+			actual:      "25-12-2023 09:25:30",
+		},
+		{
+			description: "expected time MUST support positive offset",
+			matcher:     &timeMatcher{data: "%d-%m-%Y %H:%M:%S, value=now+1h"},
+			actual:      "25-12-2023 11:25:30",
+		},
+		{
+			description: "time MUST support custom accuracy (before expected time)",
+			matcher:     &timeMatcher{data: "%d-%m-%Y %H:%M:%S, value=now(), accuracy=10m"},
+			actual:      "25-12-2023 10:10:30",
+		},
+		{
+			description: "time MUST support custom accuracy (before after time)",
+			matcher:     &timeMatcher{data: "%d-%m-%Y %H:%M:%S, value=now(), accuracy=10m"},
+			actual:      "25-12-2023 10:30:30",
+		},
+		{
+			description: "custom accuracy MUST support explicit direction ('+' for time equal or after value)",
+			matcher:     &timeMatcher{data: "%d-%m-%Y %H:%M:%S, value=now(), accuracy=+10m"},
+			actual:      "25-12-2023 10:30:30",
+		},
+		{
+			description: "custom accuracy MUST support explicit direction ('-' for time equal or before value)",
+			matcher:     &timeMatcher{data: "%d-%m-%Y %H:%M:%S, value=now(), accuracy=-10m"},
+			actual:      "25-12-2023 10:10:30",
+		},
+		{
+			description: "expected time MUST support direct specification",
+			matcher:     &timeMatcher{data: "%d-%m-%Y %H:%M:%S, value=25-12-2023 20:30:00"},
+			actual:      "25-12-2023 20:30:40",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			err := tt.matcher.MatchValues("at %s", "error-prefix", tt.actual)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func Test_TimeMatcher_MatchValues_Errors(t *testing.T) {
+	oldNowTimeFunc := nowTimeFunc
+	nowTimeFunc = func() time.Time {
+		return time.Date(2023, 12, 25, 10, 20, 30, 0, time.Local)
+	}
+	defer func() {
+		nowTimeFunc = oldNowTimeFunc
+	}()
+
+	makeMatchError := func(text, expected, actual string) string {
+		return fmt.Sprintf("at 'error-prefix' %s:\n     expected: %s\n       actual: %s",
+			text, expected, actual)
+	}
+
 	tests := []struct {
 		description string
 		matcher     *timeMatcher
@@ -14,58 +118,84 @@ func Test_TimeMatcher_MatchValues(t *testing.T) {
 		wantErr     string
 	}{
 		{
-			description: "valid time match",
+			description: "invalid actual type",
 			matcher:     &timeMatcher{data: "%Y-%m-%d"},
-			actual:      "2023-12-25",
+			actual:      nil,
+			wantErr:     makeMatchError("type mismatch", "string", "<nil>"),
 		},
 		{
-			description: "invalid time format",
+			description: "invalid strftime format specified",
+			matcher:     &timeMatcher{data: "%Y-%m-%!"},
+			actual:      "12-25-2023",
+			wantErr:     "at 'error-prefix': pattern '%Y-%m-%!': strftime: unsupported directive: %! ",
+		},
+		{
+			description: "time doesn't match to specified strftime format",
 			matcher:     &timeMatcher{data: "%Y-%m-%d"},
 			actual:      "12-25-2023",
-			wantErr:     "'error-prefix': time does not match the template:\n     expected: $matchTime(%Y-%m-%d)\n       actual: 12-25-2023",
+			wantErr:     makeMatchError("time does not match the template", "$matchTime(%Y-%m-%d)", "12-25-2023"),
+		},
+		{
+			description: "time doesn't match to specified golang format",
+			matcher:     &timeMatcher{data: "2006-01-02"},
+			actual:      "12-25-2023",
+			wantErr:     makeMatchError("time does not match the template", "$matchTime(2006-01-02)", "12-25-2023"),
+		},
+		{
+			description: "invalid duration format in accuracy parameter",
+			matcher:     &timeMatcher{data: "%Y-%m-%d, accuracy=some-wrong-value"},
+			actual:      "12-25-2023",
+			wantErr:     "at 'error-prefix': parameter 'accuracy': wrong duration value 'some-wrong-value'",
+		},
+		{
+			description: "invalid duration format in value parameter",
+			matcher:     &timeMatcher{data: "%Y-%m-%d, value=now-1dddd"},
+			actual:      "12-25-2023",
+			wantErr:     "at 'error-prefix': parameter 'value': wrong duration value '-1dddd'",
+		},
+		{
+			description: "invalid parameter name",
+			matcher:     &timeMatcher{data: "%Y-%m-%d,fakeparam=aaaa"},
+			actual:      "12-25-2023",
+			wantErr:     "at 'error-prefix': parameter 'fakeparam=aaaa': unknown parameter name",
+		},
+		{
+			description: "WHEN actual time before (expected-accuracy) MUST fail with error",
+			matcher:     &timeMatcher{data: "%d-%m-%Y %H:%M:%S, value=now()"},
+			actual:      "25-12-2023 10:15:00",
+			wantErr:     makeMatchError("values do not match", "25-12-2023 10:15:30 ... 25-12-2023 10:25:30", "25-12-2023 10:15:00"),
+		},
+		{
+			description: "WHEN actual time after (expected+accuracy) MUST fail with error",
+			matcher:     &timeMatcher{data: "%d-%m-%Y %H:%M:%S, value=now()"},
+			actual:      "25-12-2023 10:26:00",
+			wantErr:     makeMatchError("values do not match", "25-12-2023 10:15:30 ... 25-12-2023 10:25:30", "25-12-2023 10:26:00"),
+		},
+		{
+			description: "WHEN custom accuracy has explicit + actual time before expected MUST fail with error",
+			matcher:     &timeMatcher{data: "%d-%m-%Y %H:%M:%S, value=now(), accuracy=+10m"},
+			actual:      "25-12-2023 10:20:00",
+			wantErr:     makeMatchError("values do not match", "25-12-2023 10:20:30 ... 25-12-2023 10:30:30", "25-12-2023 10:20:00"),
+		},
+		{
+			description: "WHEN custom accuracy has explicit - actual time after expected MUST fail with error",
+			matcher:     &timeMatcher{data: "%d-%m-%Y %H:%M:%S, value=now(), accuracy=-10m"},
+			actual:      "25-12-2023 10:21:00",
+			wantErr:     makeMatchError("values do not match", "25-12-2023 10:10:30 ... 25-12-2023 10:20:30", "25-12-2023 10:21:00"),
+		},
+		{
+			description: "WHEN value parameter doesn't match pattern check MUST fail",
+			matcher:     &timeMatcher{data: "%d-%m-%Y %H:%M:%S, value=2023-12-25 20:30:00"},
+			actual:      "25-12-2023 20:30:40",
+			wantErr:     "at 'error-prefix': parameter 'value': time value '2023-12-25 20:30:00' doesn't match pattern '%d-%m-%Y %H:%M:%S'",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			err := tt.matcher.MatchValues("%s:", "error-prefix", tt.actual)
-			if tt.wantErr == "" {
-				require.NoError(t, err)
-			} else {
-				require.Error(t, err)
-				require.Equal(t, tt.wantErr, err.Error())
-			}
-		})
-	}
-}
-
-func Test_convertPythonToGoFormat(t *testing.T) {
-	tests := []struct {
-		name  string
-		input string
-		want  string
-	}{
-		{
-			name:  "basic date-time format",
-			input: "%Y-%m-%d %H:%M:%S",
-			want:  "2006-01-02 15:04:05",
-		},
-		{
-			name:  "month and day",
-			input: "%B %d, %Y",
-			want:  "January 02, 2006",
-		},
-		{
-			name:  "12-hour format with AM/PM",
-			input: "%I:%M %p",
-			want:  "03:04 PM",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := convertPythonToGoFormat(tt.input)
-			require.Equal(t, tt.want, got)
+			err := tt.matcher.MatchValues("at %s", "error-prefix", tt.actual)
+			require.Error(t, err)
+			require.Equal(t, tt.wantErr, err.Error())
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -8,19 +8,21 @@ require (
 	github.com/joho/godotenv v1.3.0
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.12
+	github.com/ncruces/go-strftime v0.1.9
 	github.com/stretchr/testify v1.7.1
 	github.com/tidwall/gjson v1.17.0
+	github.com/tidwall/match v1.1.1
+	github.com/xhit/go-str2duration/v2 v2.1.0
 	golang.org/x/sync v0.4.0
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
 	golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
 github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -15,6 +16,8 @@ github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdhx/f4=
+github.com/ncruces/go-strftime v0.1.9/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -26,6 +29,8 @@ github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=
+github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
 golang.org/x/sync v0.4.0 h1:zxkM55ReGkDlKSM+Fu41A+zmbZuaPVbGMzvvdUPznYQ=
 golang.org/x/sync v0.4.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
### $matchTime

The `$matchTime` function is allows you to validate timestamp strings in response, mock request, DB query results according to specific time format patterns.
Unlike the more general `$matchRegexp`, `$matchTime` is designed specifically for time validation.
This feature is used when you cannot specify the exact time (for example, the time in the response depends on the current time).

The basic syntax for using `$matchTime` is:

```yaml
$matchTime(format_string[, parameter=value][, ...])
```

where:
- `format_string` is a valid [Go time format](https://pkg.go.dev/time#pkg-constants) or [Python time format](https://docs.python.org/3/library/datetime.html#format-codes) pattern
- optional parameters can be added to customize the time matching behavior

#### Basic Format Matching

The simplest usage of `$matchTime` validates that a timestamp string matches the specified format:

```yaml
  ...
  response:
    200: >
      {
        "id": "12345",
        "created_at": "$matchTime(2006-01-02T15:04:05Z07:00)",
        "updated_at": "$matchTime(%Y-%m-%dT%H:%M:%S%z)",
        "event_date": "$matchTime(Jan 2, 2006)",
        "scheduled_time": "$matchTime(%H:%M:%S)"
      }
  ...
```

*NOTE*: For consistency, try to stick to one format style (Go or Python format) in all tests.

#### `accuracy` parameter

Defines the acceptable time difference when using the `value` parameter:

- `accuracy=duration` - sets a bidirectional time window (e.g., `accuracy=5m` for ±5 minutes)
- `accuracy=+duration` - sets a forward-only time window (e.g., `accuracy=+10m` for 0 to +10 minutes)
- `accuracy=-duration` - sets a backward-only time window (e.g., `accuracy=-10m` for -10 to 0 minutes)

By default, `accuracy` is set to ±5 minutes when using any `value`.

```yaml
response:
  200: >
    {
      "timestamp_precise": "$matchTime(%Y-%m-%d %H:%M:%S, value=now, accuracy=1m)",
      "timestamp_future": "$matchTime(%Y-%m-%d %H:%M:%S, value=now, accuracy=+30m)",
      "timestamp_past": "$matchTime(%Y-%m-%d %H:%M:%S, value=now, accuracy=-30m)"
    }
```

*NOTE*: `duration` should be defined using Go [time duration string](https://pkg.go.dev/time#ParseDuration). For convenience, days (`d`) and weeks (`w`) are also supported.

#### `value` parameter

Allows you to specify an expected time value to match against:

- `value=now` or `value=now()` - matches times around the current system time
- `value=now±offset` - matches times offset from the current time (e.g., `value=now-1h`, `value=now+30m`)
- `value=specific_time`- matches a specific time in the same format as the pattern (e.g., `value=25-12-2023 10:20:30` for format `%d-%m-%Y %H:%M:%S`)

```yaml
response:
  200: >
    {
      "last_login": "$matchTime(%Y-%m-%d %H:%M:%S, value=now-1h)",
      "next_scheduled": "$matchTime(%Y-%m-%d %H:%M:%S, value=now+24h)",
      "specific_date": "$matchTime(%d-%m-%Y %H:%M:%S, value=25-12-2023 10:20:30)"
    }
```

*NOTE*: `offset` should be defined using Go [time duration string](https://pkg.go.dev/time#ParseDuration). For convenience, days (`d`) and weeks (`w`) are also supported.

fixes https://github.com/lamoda/gonkey/issues/257