### PR TITLE
new: improve errors for mocks declaration

### DIFF
--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -15,7 +15,7 @@ threshold:
   package: 0
 
   # Minimum overall project coverage percentage required.
-  total: 80
+  total: 84
 
 # Holds regexp rules which will override thresholds for matched files or packages 
 # using their paths.

--- a/colorize/error.go
+++ b/colorize/error.go
@@ -102,6 +102,14 @@ func NewNotEqualError(pattern, entity string, expected, actual interface{}) *Err
 }
 
 // TODO: remove this hack
+func HasPathComponent(err error) bool {
+	pErr, ok := err.(*Error)
+	if !ok {
+		return false
+	}
+	return pErr.parts[0].Text() == "path " && len(pErr.parts) >= 3
+}
+
 func RemovePathComponent(err error) error {
 	pErr, ok := err.(*Error)
 	if !ok {

--- a/mocks/loader.go
+++ b/mocks/loader.go
@@ -82,7 +82,14 @@ func (l *loaderImpl) loadDefinition(path string, rawDef interface{}) (*Definitio
 	}
 
 	wrap := func(err error) error {
-		return colorize.NewEntityError("strategy %s", strategyName).SetSubError(err)
+		if colorize.HasPathComponent(err) {
+			return err
+		}
+		err = colorize.NewEntityError("strategy %s", strategyName).SetSubError(err)
+		if path == "$" {
+			return err
+		}
+		return colorize.NewEntityError("path %s", path).SetSubError(err)
 	}
 
 	replyStrategy, err := l.loadStrategy(path, strategyName, def, &ak)
@@ -108,7 +115,6 @@ func (l *loaderImpl) loadDefinition(path string, rawDef interface{}) (*Definitio
 
 func (l *loaderImpl) loadStrategy(path, strategyName string, definition map[interface{}]interface{},
 	ak *[]string) (ReplyStrategy, error) {
-	path = path + "." + strategyName
 	switch strategyName {
 	case "nop":
 		return NewNopReply(), nil

--- a/mocks/strategy_based_on_request_reply.go
+++ b/mocks/strategy_based_on_request_reply.go
@@ -2,8 +2,8 @@ package mocks
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
-	"strconv"
 	"sync"
 )
 
@@ -24,7 +24,7 @@ func (l *loaderImpl) loadBasedOnRequestReplyStrategy(path string, def map[interf
 		if !ok {
 			return nil, errors.New("'uris' list item must be a map")
 		}
-		def, err := l.loadDefinition(path+"."+strconv.Itoa(i), v)
+		def, err := l.loadDefinition(fmt.Sprintf("%s.uris[%d]", path, i), v)
 		if err != nil {
 			return nil, err
 		}

--- a/mocks/strategy_method_vary_reply.go
+++ b/mocks/strategy_method_vary_reply.go
@@ -24,7 +24,7 @@ func (l *loaderImpl) loadMethodVaryStrategy(path string, def map[interface{}]int
 		if !ok {
 			return nil, fmt.Errorf("method '%v' has non-string name", method)
 		}
-		def, err := l.loadDefinition(path+"."+methodStr, v)
+		def, err := l.loadDefinition(path+".methods."+methodStr, v)
 		if err != nil {
 			return nil, err
 		}

--- a/mocks/strategy_sequential_reply.go
+++ b/mocks/strategy_sequential_reply.go
@@ -2,8 +2,8 @@ package mocks
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
-	"strconv"
 	"sync"
 )
 
@@ -17,7 +17,7 @@ func (l *loaderImpl) loadSequenceReplyStrategy(path string, def map[interface{}]
 	}
 	strategies := []*Definition{}
 	for i, v := range seqSlice {
-		def, err := l.loadDefinition(path+"."+strconv.Itoa(i), v)
+		def, err := l.loadDefinition(fmt.Sprintf("%s.sequence[%d]", path, i), v)
 		if err != nil {
 			return nil, err
 		}

--- a/mocks/strategy_uri_vary_reply.go
+++ b/mocks/strategy_uri_vary_reply.go
@@ -31,7 +31,7 @@ func (l *loaderImpl) loadUriVaryReplyStrategy(path string, def map[interface{}]i
 		if !ok {
 			return nil, fmt.Errorf("uri '%v' has non-string name", uri)
 		}
-		def, err := l.loadDefinition(path+"."+uriStr, v)
+		def, err := l.loadDefinition(path+".uris."+uriStr, v)
 		if err != nil {
 			return nil, err
 		}

--- a/mocks/testdata/strategy/based_on_request_parse_errors.yaml
+++ b/mocks/testdata/strategy/based_on_request_parse_errors.yaml
@@ -52,7 +52,7 @@
           statusCode: 201
   meta:
     expected: |
-       load definition for 'someservice': strategy 'basedOnRequest': strategy 'constant': 'body' key required
+       load definition for 'someservice': path '$.uris[0]': strategy 'constant': 'body' key required
 
 - name: WHEN 'basedOnRequest' strategy has unknown key load definition MUST fail with error
   method: GET

--- a/mocks/testdata/strategy/long_error.yaml
+++ b/mocks/testdata/strategy/long_error.yaml
@@ -1,5 +1,3 @@
-# TODO:
-# load definition for 'someservice': at path '$.sequence.0.methods.GET.uris./test/path.uris.0': strategy 'constant': 'body' key required
 - name: sequence strategy MUST select first response on first request
   method: GET
   path: /test/path
@@ -21,4 +19,4 @@
                       statusCode: 201
   meta:
     expected: |
-       load definition for 'someservice': strategy 'sequence': strategy 'methodVary': strategy 'uriVary': strategy 'basedOnRequest': strategy 'constant': 'body' key required
+       load definition for 'someservice': path '$.sequence[0].methods.GET.uris./test/path.uris[0]': strategy 'constant': 'body' key required

--- a/mocks/testdata/strategy/method_vary_parse_errors.yaml
+++ b/mocks/testdata/strategy/method_vary_parse_errors.yaml
@@ -54,7 +54,7 @@
           statusCode: 200
   meta:
     expected: |
-       load definition for 'someservice': strategy 'methodVary': strategy 'constant': 'body' key required
+       load definition for 'someservice': path '$.methods.POST': strategy 'constant': 'body' key required
 
 - name: WHEN 'methodVary' strategy has unknown key load definition MUST fail with error
   method: GET

--- a/mocks/testdata/strategy/sequence_parse_errors.yaml
+++ b/mocks/testdata/strategy/sequence_parse_errors.yaml
@@ -36,7 +36,7 @@
           statusCode: 201
   meta:
     expected: |
-       load definition for 'someservice': strategy 'sequence': strategy 'constant': 'body' key required
+       load definition for 'someservice': path '$.sequence[0]': strategy 'constant': 'body' key required
 
 - name: WHEN 'sequence' strategy has unknown key load definition MUST fail with error
   method: GET

--- a/mocks/testdata/strategy/uri_vary_parse_errors.yaml
+++ b/mocks/testdata/strategy/uri_vary_parse_errors.yaml
@@ -54,7 +54,7 @@
           statusCode: 200
   meta:
     expected: |
-       load definition for 'someservice': strategy 'uriVary': strategy 'constant': 'body' key required
+       load definition for 'someservice': path '$.uris./test/path': strategy 'constant': 'body' key required
 
 - name: WHEN parsing of uriVary basePath fail parser MUST fail with error
   method: get

--- a/testloader/yaml_file/yaml_file.go
+++ b/testloader/yaml_file/yaml_file.go
@@ -1,7 +1,9 @@
 package yaml_file
 
 import (
+	"fmt"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -23,8 +25,13 @@ func NewLoader(testsLocation string) *YamlFileLoader {
 }
 
 func (l *YamlFileLoader) Load() ([]models.TestInterface, error) {
+	_, err := os.Stat(l.testsLocation)
+	if err != nil && os.IsNotExist(err) {
+		return nil, fmt.Errorf("file or directory with tests '%s' does not exist", l.testsLocation)
+	}
+
 	var tests []models.TestInterface
-	err := filepath.WalkDir(l.testsLocation, func(relpath string, d fs.DirEntry, err error) error {
+	err = filepath.WalkDir(l.testsLocation, func(relpath string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
For declaration:
```
- name: sequence strategy MUST select first response on first request
  method: GET
  path: /test/path
  response:
    202: ""
  mocks:
    someservice:
      strategy: sequence
      sequence:
        - strategy: methodVary
          methods:
            GET:
              strategy: uriVary
              uris:
                /test/path:
                  strategy: basedOnRequest
                  uris:
                    - strategy: constant
                      statusCode: 201
```
error changed from
```
load definition for 'someservice': strategy 'sequence': strategy 'methodVary': strategy 'uriVary': strategy 'basedOnRequest': strategy 'constant': 'body' key required
```
to
```
load definition for 'someservice': path '$.sequence[0].methods.GET.uris./test/path.uris[0]': strategy 'constant': 'body' key required
```